### PR TITLE
fix: properly merge config props with default config

### DIFF
--- a/packages/solid-snowfall/src/Snowfall.tsx
+++ b/packages/solid-snowfall/src/Snowfall.tsx
@@ -26,7 +26,7 @@ export const Snowfall: Component<SnowfallProps> = (props) => {
     ["snowflakeCount", "style"],
   );
 
-  const config = mergeProps(configProps, defaultConfig);
+  const config = mergeProps(defaultConfig, configProps);
 
   const mergedStyle = () => ({
     ...snowfallBaseStyle,


### PR DESCRIPTION
This PR addresses the issue of prop merging in the `Snowfall` component. Previously, customization of the configuration was not possible because it was consistently overridden by the default props. Now, user-provided props are properly respected.

For more details, check out the examples here:
https://docs.solidjs.com/reference/reactive-utilities/merge-props